### PR TITLE
make it compileable on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ project(simple_sqlite C)
 
 set(CMAKE_C_STANDARD 11)
 
+# issue #1
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        set(CMAKE_C_FLAGS "-Wno-implicit-function-declaration")
+endif()
+
 include_directories(core)
 
 add_executable(simple_sqlite

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compile and running instructions for Unix
 4. Build with make
 <br/>`make`
 5. Run test 
-<br/>`./simple-sqlite`
+<br/>`./simple_sqlite`
 
 Use as your own Paging library
 ========


### PR DESCRIPTION
Fix #1 .

Add `-Wno-implicit-function-declaration` to `CFLAGS` when compiling on macOS. Not elegant but it works.